### PR TITLE
Return changes from result importer updates

### DIFF
--- a/server/apps/results/importers.py
+++ b/server/apps/results/importers.py
@@ -265,3 +265,4 @@ class ResultCSVImporter(BaseCSVImporter):
         result.import_batch = batch
         result.full_clean()
         result.save()
+        return changes


### PR DESCRIPTION
## Summary
- return the change summary from `_update_result` after persisting updates so callers can differentiate no-ops

## Testing
- `python manage.py test apps.results.tests.ResultCSVImporterTests` *(fails: IndentationError in apps/results/tests.py:106)*

------
https://chatgpt.com/codex/tasks/task_e_68d865799e348323a9d695be8b5a6a9e