### PR TITLE
Fix results importer tests initialization

### DIFF
--- a/server/apps/results/tests.py
+++ b/server/apps/results/tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from datetime import date, datetime
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
@@ -91,27 +92,52 @@ class ResultModelTests(TestCase):
 
 class ResultCSVImporterTests(TestCase):
     def setUp(self) -> None:
+        super().setUp()
 
+        user_model = get_user_model()
+        self.staff_user = user_model.objects.create_user(
+            username="importer",
+            email="importer@pmc.edu.pk",
+            password="testpass123",
+            is_staff=True,
+        )
+
+        self.student = Student.objects.create(
+            official_email="student@pmc.edu.pk",
+            roll_number="PMC-001",
+            display_name="Test Student",
+        )
+
+        self.initial_batch = ImportBatch.objects.create(
+            import_type=ImportBatch.ImportType.RESULTS,
+            started_by=self.staff_user,
+            is_dry_run=False,
+        )
+
+        next_year = datetime.now().year + 1
+        self.existing_result = Result.objects.create(
+            student=self.student,
+            import_batch=self.initial_batch,
             respondent_id="resp-1",
             roll_number=self.student.roll_number,
             name="Test Student",
             block="E",
-
+            year=next_year,
             subject="Pathology",
             written_marks=Decimal("65.00"),
             viva_marks=Decimal("20.00"),
             total_marks=Decimal("85.00"),
             grade="B",
-            exam_date=date(datetime.now().year + 1, 1, 15),
+            exam_date=date(next_year, 1, 15),
         )
 
-        next_year = datetime.now().year + 1
-        self.csv_payload = f"""respondent_id,roll_no,name,block,year,subject,written_marks,viva_marks,total_marks,grade,exam_date
-resp-1,PMC-001,Test Student,E,{next_year},Pathology,70,20,90,A,{next_year}-01-15
-,PMC-001,Test Student,E,{next_year},Anatomy,80,20,100,A+,{next_year}-01-16
-,PMC-001,Test Student,E,{next_year},Physiology,50,20,60,A,{next_year}-01-17
-,PMC-999,Missing Student,E,{next_year},Pathology,60,20,80,B,{next_year}-01-18
-"""
+        self.csv_payload = (
+            "respondent_id,roll_no,name,block,year,subject,written_marks,viva_marks,total_marks,grade,exam_date\n"
+            f"resp-1,PMC-001,Test Student,E,{next_year},Pathology,70,20,90,A,{next_year}-01-15\n"
+            f",PMC-001,Test Student,E,{next_year},Anatomy,80,20,100,A+,{next_year}-01-16\n"
+            f",PMC-001,Test Student,E,{next_year},Physiology,50,20,60,A,{next_year}-01-17\n"
+            f",PMC-999,Missing Student,E,{next_year},Pathology,60,20,80,B,{next_year}-01-18"
+        )
 
     def _build_stream(self) -> io.StringIO:
         return io.StringIO(self.csv_payload)


### PR DESCRIPTION
## Summary
- add missing datetime imports required by the results tests
- seed staff user, student, and existing result in importer test setup

## Testing
- python manage.py test apps.results

------
https://chatgpt.com/codex/tasks/task_e_68d865785af883238f5f5c9d4a940f02