### PR TITLE
Restore student model helpers and importer safeguards

### DIFF
--- a/server/apps/accounts/importers.py
+++ b/server/apps/accounts/importers.py
@@ -128,6 +128,8 @@ class StudentCSVImporter(BaseCSVImporter):
             if not row.get(column):
                 errors.append(f"{column} is required.")
 
+        return errors
+
 
     def _normalize_status(self, raw_status: str | None) -> str:
         value = (raw_status or "").strip().lower()

--- a/server/apps/accounts/models.py
+++ b/server/apps/accounts/models.py
@@ -69,10 +69,28 @@ class Student(models.Model):
     )
     status = models.CharField(
         max_length=10,
+        choices=Status.choices,
+        default=Status.ACTIVE,
+        help_text="Whether the student account is active on the portal.",
+    )
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
- main
+
+    @property
+    def is_active(self) -> bool:
+        """Return ``True`` when the student is marked as active."""
+
+        return self.status == self.Status.ACTIVE
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        """Human readable representation used in admin and logs."""
+
+        if self.display_name:
+            return self.display_name
+        if self.official_email:
+            return self.official_email
+        return self.roll_number or "Student"
 
     class Meta:
         ordering = ("official_email",)
@@ -80,4 +98,3 @@ class Student(models.Model):
             models.Index(fields=["roll_number"], name="student_roll_number_idx"),
             models.Index(fields=["status"], name="student_status_idx"),
         ]
- copilot/fix-36049be9-cfe8-45af-8824-e9e219913d9e

--- a/server/apps/accounts/pipeline.py
+++ b/server/apps/accounts/pipeline.py
@@ -58,7 +58,11 @@ def associate_student_profile(
     if user and (user.is_staff or user.is_superuser):
         Student.objects.update_or_create(
             official_email=email,
-            defaults={"display_name": display_name},
+            defaults={
+                "display_name": display_name,
+                "user": user,
+                "status": Student.Status.ACTIVE,
+            },
         )
         return
 


### PR DESCRIPTION
## Summary
- finish the Student.status field configuration and restore helper properties for parity with migrations
- ensure staff logins link to student records while keeping them active by default
- return validation errors from the student importer to keep invalid rows out of the created count

## Testing
- python manage.py makemigrations accounts
- python manage.py migrate
- python manage.py test apps.accounts

------
https://chatgpt.com/codex/tasks/task_e_68d86a101bbc8323915469b8fbe4a3bb