### PR TITLE
Align Student model timestamps with migrations

### DIFF
--- a/server/apps/accounts/models.py
+++ b/server/apps/accounts/models.py
@@ -71,8 +71,16 @@ class Student(models.Model):
         max_length=10,
         choices=Status.choices,
         default=Status.ACTIVE,
-        help_text="Current status of the student.",
+        help_text="Current status of the student record.",
     )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    @property
+    def is_active(self) -> bool:
+        """Return ``True`` when the student's status is active."""
+
+        return self.status == Student.Status.ACTIVE
 
     class Meta:
         ordering = ("official_email",)

--- a/server/apps/accounts/models.py
+++ b/server/apps/accounts/models.py
@@ -79,7 +79,6 @@ class Student(models.Model):
     @property
     def is_active(self) -> bool:
         """Return ``True`` when the student's status is active."""
-
         return self.status == Student.Status.ACTIVE
 
     class Meta:


### PR DESCRIPTION
## Summary
- add created_at/updated_at audit fields to the Student model to match historical migrations
- expose an is_active property while keeping the queryset helper aligned with the ACTIVE status choice

## Testing
- python manage.py makemigrations accounts
- python manage.py migrate
- python manage.py shell -c "from django.conf import settings; settings.ALLOWED_HOSTS.append('testserver'); from django.contrib.auth import get_user_model; from django.test import Client; User=get_user_model(); user, _ = User.objects.get_or_create(username='admin', defaults={'email':'admin@example.com'}); user.is_staff = True; user.is_superuser = True; user.set_password('pass'); user.save(); client=Client(); client.force_login(user); resp=client.get('/admin/accounts/student/'); assert resp.status_code == 200, resp.status_code"
- python manage.py test apps.accounts


------
https://chatgpt.com/codex/tasks/task_e_68d8f955c3a48323b88ade7bd77c4dd8