### PR TITLE
Ensure static assets directory exists for collectstatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__/
 
 # Django
 *.log
-static/
+/static/
 media/
 
 # SQLite (development fallback)

--- a/server/static/css/base.css
+++ b/server/static/css/base.css
@@ -1,0 +1,29 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+.toast {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background-color: #0f172a;
+  color: #fff;
+  box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.25);
+  font-size: 0.95rem;
+  z-index: 50;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -10,35 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-
-    <style>
-      :root {
-        color-scheme: light;
-        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background-color: #f8fafc;
-      }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        background-color: #f8fafc;
-      }
-      .toast {
-        position: fixed;
-        top: 1.5rem;
-        right: 1.5rem;
-        padding: 0.75rem 1rem;
-        border-radius: 0.75rem;
-        background-color: #0f172a;
-        color: #fff;
-        box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.25);
-        font-size: 0.95rem;
-        z-index: 50;
-      }
-      a {
-        color: inherit;
-        text-decoration: none;
-      }
-    </style>
+    <link rel="stylesheet" href="{% static 'css/base.css' %}" />
   </head>
   <body>
     {% if messages %}


### PR DESCRIPTION
## Summary
- allow tracking the project static directory by scoping the static ignore rule to the repository root
- move the shared base template styles into `server/static/css/base.css` so STATICFILES_DIRS resolves

## Testing
- python manage.py collectstatic --noinput

------
https://chatgpt.com/codex/tasks/task_e_68d8f9571648832393a627b3fabf9981